### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete string escaping or encoding

### DIFF
--- a/src/lib/utils/parseSvgContent.ts
+++ b/src/lib/utils/parseSvgContent.ts
@@ -12,6 +12,7 @@ export const parseSvgContent = (content: string) => {
 		return `<svg${attrs} width="\${width}" height="\${height}" \${restAttrs}>`;
 	});
 
+	content = content.replace(/\\/g, '\\\\');
 	content = content.replace(/`/g, '\\`');
 
 	return {


### PR DESCRIPTION
Potential fix for [https://github.com/selemondev/svgl-svelte/security/code-scanning/4](https://github.com/selemondev/svgl-svelte/security/code-scanning/4)

To fix this safely without changing intended functionality, make the template-literal escaping complete by escaping **all backslashes** before escaping backticks.

Best minimal fix in `src/lib/utils/parseSvgContent.ts`:
- In the region around line 15, add:
  - `content = content.replace(/\\/g, '\\\\');`
- Keep the existing backtick escaping line after it:
  - `content = content.replace(/`/g, '\\`');`

Order matters: escaping backslashes first avoids newly inserted backslashes being reprocessed incorrectly and ensures sequences like `\`` remain safe when embedded in `` `...` ``.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
